### PR TITLE
Dockerfile: add tools useful for MIPS dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@
 FROM ubuntu:xenial
 MAINTAINER IMGTEC
 
-# add multiarch support
+# Add multiarch support
 RUN dpkg --add-architecture i386
 
 # Openwrt dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-binutils flex perl gawk grep file openssl bzip2 unzip zip \
+binutils flex perl gawk grep file openssl bzip2 unzip zip rsync bc \
 build-essential bsdmainutils cmake device-tree-compiler \
 libncurses5-dev libncursesw5-dev libssl-dev zlib1g-dev libc6:i386 \
 ca-certificates wget curl subversion git mercurial \
@@ -21,9 +21,18 @@ RUN wget -O xc32.run http://ww1.microchip.com/downloads/en/DeviceDoc/xc32-v1.34-
 chmod a+x xc32.run && \
 ./xc32.run --mode unattended --unattendedmodeui none --netservername localhost && \
 rm xc32.run
+
+# MIPS official toolchain
+RUN mkdir -p /opt/toolchains && wget -qO- http://codescape-mips-sdk.imgtec.com/components/toolchain/2016.05-03/Codescape.GNU.Tools.Package.2016.05-03.for.MIPS.IMG.Linux.CentOS-5.x86.tar.gz | tar -xz -C /opt/toolchains/
+
+# Useful tools
+RUN wget -O /usr/bin/checkpatch.pl https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl && \
+chmod +x /usr/bin/checkpatch.pl
+
+# Set all env in one go to avoid too many layers
 ENV PATH $PATH:/opt/microchip/xc32/v1.34/bin/
 
-# add and use build user
+# Add and use build user
 RUN useradd -m -p build build
 USER build
 WORKDIR /home/build/


### PR DESCRIPTION
This connects CreatorDev/openwrt#48

Added a selection of tools that are useful when working with any of
the MIPS creator platform projects in general. Most significantly
adding the official toolchain.

Also done a bit of cleanup to to comments and layer managment.

Signed-off-by: Ian Pozella <Ian.Pozella@imgtec.com>